### PR TITLE
changing how dict is initialized within convert_to_chips

### DIFF
--- a/chip.py
+++ b/chip.py
@@ -9,7 +9,9 @@ class Chip() :
         return f'${self.value}'
 
 # NEVER use second and third parameters     
-def convert_to_chips(amount, dict={}, i=len(Chip.values)-1) :
+def convert_to_chips(amount, dict=None, i=len(Chip.values)-1) :
+    if dict is None:
+        dict = {}
     if amount <= 0 :
         while i >= 0 :
             dict[f'${Chip.values[i]} chip'] = 0


### PR DESCRIPTION
dict initialized with default values in convert_to_chips function statement, resulting in all players referencing the same chip dictionary. And end-results (display_accounts()) shows incorrect chip status